### PR TITLE
NLog: remove useless external refs

### DIFF
--- a/BrowserLog.NLog/packages.config
+++ b/BrowserLog.NLog/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NLog" version="4.2.3" targetFramework="net45" />
-  <package id="NLog.Config" version="4.2.3" targetFramework="net45" />
-  <package id="NLog.Schema" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- NLog.Schema is useful for config intellisense
- NLog.Config is useful for getting an example config file

Those refs are useless in BrowserLog.NLog library, as any config exemple and intellisense support should remain a choice, not an obligation, when getting BrowserLog.Nlog from nuget.
